### PR TITLE
Avoid doctrine deprecation warnings

### DIFF
--- a/Command/RunCommand.php
+++ b/Command/RunCommand.php
@@ -329,7 +329,7 @@ class RunCommand extends Command
                 $data['job']->checked();
                 $em = $this->getEntityManager();
                 $em->persist($data['job']);
-                $em->flush($data['job']);
+                $em->flush();
 
                 continue;
             }
@@ -372,7 +372,7 @@ class RunCommand extends Command
         $job->setState(Job::STATE_RUNNING);
         $em = $this->getEntityManager();
         $em->persist($job);
-        $em->flush($job);
+        $em->flush();
 
         $args = $this->getBasicCommandLineArgs();
         $args[] = $job->getCommand();

--- a/Command/ScheduleCommand.php
+++ b/Command/ScheduleCommand.php
@@ -106,7 +106,7 @@ class ScheduleCommand extends Command
                 $job = $scheduler->createJob($name, $lastRunAt);
                 $em = $this->registry->getManagerForClass(Job::class);
                 $em->persist($job);
-                $em->flush($job);
+                $em->flush();
             }
         }
     }

--- a/Entity/Repository/JobManager.php
+++ b/Entity/Repository/JobManager.php
@@ -37,7 +37,7 @@ class JobManager
     private $dispatcher;
     private $registry;
     private $retryScheduler;
-    
+
     public function __construct(ManagerRegistry $managerRegistry, EventDispatcherInterface $eventDispatcher, RetryScheduler $retryScheduler)
     {
         $this->registry = $managerRegistry;
@@ -71,7 +71,7 @@ class JobManager
 
         $job = new Job($command, $args, false);
         $this->getJobManager()->persist($job);
-        $this->getJobManager()->flush($job);
+        $this->getJobManager()->flush();
 
         $firstJob = $this->getJobManager()->createQuery("SELECT j FROM JMSJobQueueBundle:Job j WHERE j.command = :command AND j.args = :args ORDER BY j.id ASC")
              ->setParameter('command', $command)
@@ -82,13 +82,13 @@ class JobManager
         if ($firstJob === $job) {
             $job->setState(Job::STATE_PENDING);
             $this->getJobManager()->persist($job);
-            $this->getJobManager()->flush($job);
+            $this->getJobManager()->flush;
 
             return $job;
         }
 
         $this->getJobManager()->remove($job);
-        $this->getJobManager()->flush($job);
+        $this->getJobManager()->flush();
 
         return $firstJob;
     }
@@ -424,7 +424,7 @@ class JobManager
 
         return count($result);
     }
-    
+
     private function getJobManager(): EntityManager
     {
         return $this->registry->getManagerForClass(Job::class);

--- a/Tests/Functional/RunCommandTest.php
+++ b/Tests/Functional/RunCommandTest.php
@@ -45,7 +45,7 @@ class RunCommandTest extends BaseTestCase
     {
         $job = new Job('jms-job-queue:successful-cmd');
         $this->em->persist($job);
-        $this->em->flush($job);
+        $this->em->flush();
 
         $this->runConsoleCommand(array('--max-runtime' => 1, '--worker-name' => 'test'));
         $this->assertEquals('finished', $job->getState());
@@ -183,7 +183,7 @@ OUTPUT
         $job = new Job('jms-job-queue:sometimes-failing-cmd', array(time()));
         $job->setMaxRetries(5);
         $this->em->persist($job);
-        $this->em->flush($job);
+        $this->em->flush();
 
         $this->runConsoleCommand(array('--max-runtime' => 12, '--verbose' => null, '--worker-name' => 'test'));
 
@@ -197,7 +197,7 @@ OUTPUT
         $job = new Job('jms-job-queue:never-ending');
         $job->setMaxRuntime(1);
         $this->em->persist($job);
-        $this->em->flush($job);
+        $this->em->flush();
 
         $this->runConsoleCommand(array('--max-runtime' => 1, '--worker-name' => 'test'));
         $this->assertEquals('terminated', $job->getState());
@@ -263,7 +263,7 @@ OUTPUT
     {
         $job = new Job('jms-job-queue:throws-exception-cmd');
         $this->em->persist($job);
-        $this->em->flush($job);
+        $this->em->flush();
 
         $this->assertNull($job->getStackTrace());
         $this->assertNull($job->getMemoryUsage());


### PR DESCRIPTION
Updated all calls to EntityManager::flush() to no pass an entity, because this caused deprecation warnings.
Now it will just flush all pending write operations.