### PR TITLE
[Composer] Limited doctrine/collections to ^1.8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,9 +16,10 @@
     ],
     "require": {
         "php": "^7.3 || ^8.0",
-        "symfony/framework-bundle": "^5.0",
-        "symfony/error-handler": "^5.0",
+        "doctrine/collections": "^1.8",
         "doctrine/common": "^3.0",
+        "symfony/error-handler": "^5.0",
+        "symfony/framework-bundle": "^5.0",
         "symfony/process": "^5.0"
     },
     "require-dev": {
@@ -49,5 +50,8 @@
         "branch-alias": {
             "dev-master": "4.0.x-dev"
         }
+    },
+    "config": {
+        "sort-packages": true
     }
 }


### PR DESCRIPTION
Right now our tests on 4.3 are failing with:
```
Executing script cache:clear [KO]
 [KO]
Script cache:clear returned with error code 255
!!  
!!   // Clearing the cache for the behat environment with debug                     
!!   // true                                                                        
!!  
!!  PHP Fatal error:  Class JMS\JobQueueBundle\Entity\Listener\PersistentRelatedEntitiesCollection 
contains 2 abstract methods and must therefore be declared abstract 
or implement the remaining methods 
(Doctrine\Common\Collections\ReadableCollection::findFirst, 
Doctrine\Common\Collections\ReadableCollection::reduce) in 
/var/www/vendor/ezsystems/job-queue-bundle/JMS/JobQueueBundle/Entity/
Listener/PersistentRelatedEntitiesCollection.php on line 22
```

Link: https://github.com/ibexa/commerce/actions/runs/4308277557/jobs/7514641798

This is caused by our latest changes to website-skeleton (we don't install doctrine/collections during that phase anymore), which means that doctrine/collections v2 was available for installation.

This package uses the collection dependency (though it was not present in composer.json) and is not compatible with v2.
